### PR TITLE
improve image centroiding for noiraf

### DIFF
--- a/kai/reduce/data.py
+++ b/kai/reduce/data.py
@@ -4176,18 +4176,20 @@ def clean_makecoo(_ce, _cc, refSrc, strSrc, aotsxyRef, radecRef,
         #yref = float(values[4])
 
         image_data = fits.getdata(_ce)
-        com = ndimage.center_of_mass(image_data[int(yref-cent_box/2):int(yref+cent_box/2),int(xref-cent_box/2):int(xref+cent_box/2)])
-        xref = xref-cent_box/2 + (com[1]+0.5)
-        yref = yref-cent_box/2 + (com[0]+0.5)
+        for _ in range(5):
+            com = ndimage.center_of_mass(image_data[int(yref-cent_box/2):int(yref+cent_box/2),int(xref-cent_box/2):int(xref+cent_box/2)])
+            xref = int(xref-cent_box/2) + com[1]
+            yref = int(yref-cent_box/2) + com[0]
 
         #text = ir.imcntr(_ce, xstr, ystr, cbox=cent_box, Stdout=1)
         #values = text[0].split()
         #xstr = float(values[2])
         #ystr = float(values[4])
 
-        com = ndimage.center_of_mass(image_data[int(ystr-cent_box/2):int(ystr+cent_box/2),int(xstr-cent_box/2):int(xstr+cent_box/2)])
-        xstr = xstr-cent_box/2 + (com[1]+0.5)
-        ystr = ystr-cent_box/2 + (com[0]+0.5)
+        for _ in range(5):
+            com = ndimage.center_of_mass(image_data[int(ystr-cent_box/2):int(ystr+cent_box/2),int(xstr-cent_box/2):int(xstr+cent_box/2)])
+            xstr = int(xstr-cent_box/2) + com[1]
+            ystr = int(ystr-cent_box/2) + com[0]
 
         print('clean_makecoo: xref, yref final = {0:.2f} {1:.2f}'.format(xref, yref))
 


### PR DESCRIPTION
Existing noiraf code lead to elongated PSF, suspected centroiding issue as suggested by @nsabrams 

Proposed two changes:
1. Iterate over multiple rounds. The equivalent IRAF routine iterative twice by default.
2. Corrected the transformation from sub-image centroid to full-image centroid. The offset between the sub/full image centroids is the full image index of the (0,0) index of the sub image, which is an integer.

The default number of iterations is set two 5 times. I noticed that with twice the image is still elongated. 5 times iteration appears to yield final image comparable to using the IRAF centroiding routine.

cc @jluastro @skterry 